### PR TITLE
Remove the last part of the path from tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Then, copy the file to an easy location.
 ```bash
 git clone https://github.com/starx/bookmarks-to-linkding.git
 python3 -m venv .venv
-source .venb/bin/activate
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
 **Step 3:** Copy the bookmarks file to the project folder.
 
-**Step 4:** Add your linkding credentials
+**Step 4:** Add your linkding credentials 
 
 Get your rest api key, from your settings page.
 

--- a/linkding_importer/linkding_importer.py
+++ b/linkding_importer/linkding_importer.py
@@ -23,7 +23,7 @@ class LinkdingImporter:
             bookmarks.append({
                 "url": node["url"],
                 "title": node["name"],
-                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/") if tag]
+                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/")[:-1] if tag]
             })
         elif node.get("type") == "folder" and "children" in node:
             for child in node["children"]:
@@ -37,7 +37,7 @@ class LinkdingImporter:
             bookmarks.append({
                 "url": node["uri"],
                 "title": node["title"],
-                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/") if tag]
+                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/")[:-1] if tag]
             })
         elif node.get("type") == "text/x-moz-place-container" and "children" in node:  # Folder
             for child in node["children"]:

--- a/linkding_importer/linkding_importer.py
+++ b/linkding_importer/linkding_importer.py
@@ -23,7 +23,7 @@ class LinkdingImporter:
             bookmarks.append({
                 "url": node["url"],
                 "title": node["name"],
-                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/")[:-1] if tag]
+                "tags": [self.normalize_folder_name(tag) for tag in path.split("/") if tag]
             })
         elif node.get("type") == "folder" and "children" in node:
             for child in node["children"]:
@@ -37,7 +37,7 @@ class LinkdingImporter:
             bookmarks.append({
                 "url": node["uri"],
                 "title": node["title"],
-                "tags": [self.normalize_folder_name(tag) for tag in current_path.split("/")[:-1] if tag]
+                "tags": [self.normalize_folder_name(tag) for tag in path.split("/") if tag]
             })
         elif node.get("type") == "text/x-moz-place-container" and "children" in node:  # Folder
             for child in node["children"]:


### PR DESCRIPTION
Thanks for creating this script it's saved me a bunch of time importing my bookmarks!

I noticed when I did my import that every bookmark, along with being tagged with the folders in it's path, was additonally being tagged with the title of the bookmark itself as well. 
Perhaps this was intentional, but it wasn't useful for me so I made a very slight change to slice off the last item in the list of the split path so only the folder names are added as tags. 

While I was here I also updated the README to correct a typo in the instructions :)